### PR TITLE
VID/PIDの一致するデバイスが複合デバイスだったときに例外が発生する問題の修正

### DIFF
--- a/Host application/HID host sample/USBDevice.cs
+++ b/Host application/HID host sample/USBDevice.cs
@@ -71,6 +71,12 @@ namespace OaktreeLab.USBDevice {
                         0,
                         IntPtr.Zero
                     );
+                    // VIDとPIDが一致しているが開けないデバイスだった場合に探索に戻る
+                    if (hDev.ToInt32() <= -1)
+                    {
+                        Native.CloseHandle(hDev);
+                        continue;
+                    }
                     break;
                 }
             }


### PR DESCRIPTION
VID/PIDで探索したHIDデバイスがVendorSpecific以外のレポートを持つ場合（キーボードやマウスとVendorSpecificデバイスの複合デバイスの場合）にVendorSpecific以外のデバイスをCreateFile()で開こうとすると失敗します．
失敗した場合に読み捨てて再び開くことのできるデバイスの探索に戻るようにする必要があります．